### PR TITLE
Bugfix/functional mistakes

### DIFF
--- a/packages/ts-config-webpack-plugin/config/development.config.js
+++ b/packages/ts-config-webpack-plugin/config/development.config.js
@@ -13,7 +13,7 @@ exports = module.exports = (options) => ({
 		rules: [
 			{
 				// .ts, .tsx, .d.ts
-				test: /\.(tsx?|d.ts)$/,
+				test: /\.(tsx?|d\.ts)$/,
 				use: [
 					{
 						// enable file based cache

--- a/packages/ts-config-webpack-plugin/config/production.config.js
+++ b/packages/ts-config-webpack-plugin/config/production.config.js
@@ -14,7 +14,7 @@ exports = module.exports = (options) => ({
 		rules: [
 			{
 				// .ts, .tsx, .d.ts
-				test: /\.(tsx?|d.ts)$/,
+				test: /\.(tsx?|d\.ts)$/,
 				use: [
 					{
 						// enable file based cache

--- a/packages/ts-config-webpack-plugin/test/WebpackConfigFiles.test.js
+++ b/packages/ts-config-webpack-plugin/test/WebpackConfigFiles.test.js
@@ -1,0 +1,46 @@
+const productionConfig = require('../config/production.config');
+const developmentConfig = require('../config/development.config');
+
+function filesRegexTests(filesRegex) {
+	it('files regex matches .ts file ending', (done) => {
+		expect(filesRegex.test('demo.ts')).toBe(true);
+		done();
+	});
+
+	it('files regex matches .tsx file ending', (done) => {
+		expect(filesRegex.test('demo.tsx')).toBe(true);
+		done();
+	});
+
+	it('files regex matches .d.ts file ending', (done) => {
+		expect(filesRegex.test('demo.d.ts')).toBe(true);
+		done();
+	});
+
+	it('files regex doesn\'t match "asdfts" (escaping the first dot)', (done) => {
+		expect(filesRegex.test('asdfts')).toBe(false);
+		done();
+	});
+
+	it('files regex doesn\'t match "asdftsx" (escaping the first dot)', (done) => {
+		expect(filesRegex.test('asdftsx')).toBe(false);
+		done();
+	});
+
+	it('files regex doesn\'t match "demo.dxts" (escaping the second dot)', (done) => {
+		expect(filesRegex.test('demo.dxts')).toBe(false);
+		done();
+	});
+}
+
+describe('TsConfigWebpackPlugin production config file', () => {
+	const filesRegex = productionConfig({}).module.rules[0].test;
+
+	filesRegexTests(filesRegex);
+});
+
+describe('TsConfigWebpackPlugin development config file', () => {
+	const filesRegex = developmentConfig({}).module.rules[0].test;
+
+	filesRegexTests(filesRegex);
+});

--- a/webpage/src/components/Configurator.tsx
+++ b/webpage/src/components/Configurator.tsx
@@ -19,7 +19,7 @@ function getInitialState() {
 		configOptionKeys.forEach((key) => {
 			result[key] = initial[key] === true;
 		});
-		return initial;
+		return result;
 	} catch {
 		return {};
 	}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: link tbd.
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] tooling / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

1. The web-configurator fetches config options from the local storage and then filters out any object keys that aren't config option keys and stores the filtered data in the `result` variable. It then returns the `initial` object instead of the `result`, which doesn't make sense.

2. The webpack config files of the ts-config-webpack-plugin miss escaping the second dot of definition files.

Issue Number: N/A

## What is the new behavior?

1. With this [Commit](https://github.com/merkle-open/webpack-config-plugins/commit/271b4bee4b11d1b47a0817d1ddcf9419d2ea060e#diff-8a2f60ccfff0f01e28dbf0c91a979c2111d9a8780637d78e6023cf1e949f33ce), the `result` gets returned instead of the `initial`.

2. With this [Commit[(https://github.com/merkle-open/webpack-config-plugins/commit/43c6ecd153753e9692db3945fddd18d2175cec62), the missing escaping of the second dot gets introduced.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

## Other information
