### PR TITLE
chore: restrict webpack versions to latest compatible version

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Instead of copying loader configs from github and stackoverflow you could just a
 <br>
 </div>
 
+## Required Webpack Version
+
+The compatible version of webpack to each plugin may vary and is documented in each `package.json` file under the `peerDependencies` property.
+
 ## Quick overview
 
 ```

--- a/packages/asset-config-webpack-plugin/package.json
+++ b/packages/asset-config-webpack-plugin/package.json
@@ -20,7 +20,7 @@
     "test": "jest --runInBand --verbose"
   },
   "peerDependencies": {
-    "webpack": ">=4.36.0"
+    "webpack": ">=4.36.0 < 5"
   },
   "dependencies": {
     "font-config-webpack-plugin": "^2.0.3",

--- a/packages/common-config-webpack-plugin/package.json
+++ b/packages/common-config-webpack-plugin/package.json
@@ -24,7 +24,7 @@
     "test-watch": "jest --watch --runInBand"
   },
   "peerDependencies": {
-    "webpack": ">=4.36.0"
+    "webpack": ">=4.36.0 < 5"
   },
   "dependencies": {
     "@babel/core": "^7.13.15",

--- a/packages/font-config-webpack-plugin/package.json
+++ b/packages/font-config-webpack-plugin/package.json
@@ -20,7 +20,7 @@
     "test-watch": "jest --watch --runInBand"
   },
   "peerDependencies": {
-    "webpack": ">=4.36.0"
+    "webpack": ">=4.36.0 < 5"
   },
   "dependencies": {
     "file-loader": "^6.2.0"

--- a/packages/image-config-webpack-plugin/package.json
+++ b/packages/image-config-webpack-plugin/package.json
@@ -20,7 +20,7 @@
     "test-watch": "jest --watch --runInBand"
   },
   "peerDependencies": {
-    "webpack": ">=4.36.0"
+    "webpack": ">=4.36.0 < 5"
   },
   "dependencies": {
     "file-loader": "^6.2.0",

--- a/packages/js-config-webpack-plugin/package.json
+++ b/packages/js-config-webpack-plugin/package.json
@@ -22,7 +22,7 @@
     "@babel/core": ">=7.0.0",
     "@babel/preset-env": ">=7.0.0",
     "@babel/preset-react": ">=7.0.0",
-    "webpack": ">=4.36.0"
+    "webpack": ">=4.36.0 < 5"
   },
   "dependencies": {
     "babel-loader": "^8.2.2",

--- a/packages/scss-config-webpack-plugin/package.json
+++ b/packages/scss-config-webpack-plugin/package.json
@@ -23,7 +23,7 @@
     "test-watch": "jest --watch --runInBand"
   },
   "peerDependencies": {
-    "webpack": ">=4.36.0"
+    "webpack": ">=4.36.0 < 5"
   },
   "dependencies": {
     "autoprefixer": "^10.2.5",

--- a/packages/ts-config-webpack-plugin/package.json
+++ b/packages/ts-config-webpack-plugin/package.json
@@ -24,7 +24,7 @@
   },
   "peerDependencies": {
     "typescript": ">=3.1.0",
-    "webpack": ">=4.36.0"
+    "webpack": ">=4.36.0 < 5"
   },
   "dependencies": {
     "cache-loader": "^4.1.0",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ x ] The commit message follows our guidelines: link tbd.
- [ x ] Tests for the changes have been added (for bug fixes / features)
- [ x ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ x ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] tooling / infrastructure changes
[ ] Other... Please describe:
```

## What is the current behavior?

The latest currently supported webpack version is just below 5. Currently that limitation is not apparent.

Issue Number: #91

## What is the new behavior?

The user will get a notice in the terminal when using an incompatible webpack version and it's properly documented on which versions are compatible.

## Does this PR introduce a breaking change?

```
[ ] Yes
[ x ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
